### PR TITLE
company color brand support and hide unwanted navigation tabs

### DIFF
--- a/static/css/app.css
+++ b/static/css/app.css
@@ -4,6 +4,12 @@
   --pgweb-primary-text: #fff;
 }
 
+/* Tab hiding support */
+#nav ul li[style*="display: none"],
+#nav ul li[data-hidden="true"] {
+  display: none !important;
+}
+
 #main {
   display: none;
 }


### PR DESCRIPTION
[feat: support brand colors for company branding](https://github.com/flowbi/pgweb/commit/6f18fd65d07006cdca5a2629b055929f7b34e2ec) 

- Added CSS custom properties/variables for theming
    - --pgweb-primary-color: Main brand color (default: #79589f)
    - --pgweb-primary-text-muted: Muted text color
    - --pgweb-primary-text: Primary text color
  - Replaced hardcoded colors throughout the CSS
  - Affected elements: navigation bar, sidebar, database selector, connection buttons
  
  
[feat: add tab hiding functionality via url parameters](https://github.com/flowbi/pgweb/commit/26780dd06fbf8b1fb3fe902c0b9b2251d8118438) 

- Introduced CSS rules to hide specific navigation tabs based on their display style.
- Implemented a function to manage the visibility of navigation tabs based on URL parameters.

Ref #11, #16
  
  