### PR TITLE
feat: Tenant isolation using headers for prepending SET ROLE command

### DIFF
--- a/pkg/api/middleware.go
+++ b/pkg/api/middleware.go
@@ -1,6 +1,7 @@
 package api
 
 import (
+	"log"
 	"strings"
 
 	"github.com/gin-gonic/gin"
@@ -54,6 +55,29 @@ func corsMiddleware() gin.HandlerFunc {
 		c.Header("Access-Control-Allow-Methods", "GET, POST, OPTIONS")
 		c.Header("Access-Control-Expose-Headers", "*")
 		c.Header("Access-Control-Allow-Origin", command.Opts.CorsOrigin)
+	}
+}
+
+// Middleware to extract X-Database-Role header and set role on client
+func roleInjectionMiddleware() gin.HandlerFunc {
+	return func(c *gin.Context) {
+		// Extract X-Database-Role header
+		role := c.GetHeader("X-Database-Role")
+		
+		if role != "" {
+			// Get the current database client
+			client := DB(c)
+			if client != nil {
+				// Set the role on the client for this request
+				client.SetRole(role)
+				
+				if command.Opts.Debug {
+					log.Printf("SET ROLE middleware: role=%s, path=%s", role, c.Request.URL.Path)
+				}
+			}
+		}
+		
+		c.Next()
 	}
 }
 

--- a/pkg/api/middleware.go
+++ b/pkg/api/middleware.go
@@ -63,20 +63,20 @@ func roleInjectionMiddleware() gin.HandlerFunc {
 	return func(c *gin.Context) {
 		// Extract X-Database-Role header
 		role := c.GetHeader("X-Database-Role")
-		
+
 		if role != "" {
 			// Get the current database client
 			client := DB(c)
 			if client != nil {
 				// Set the role on the client for this request
 				client.SetRole(role)
-				
+
 				if command.Opts.Debug {
 					log.Printf("SET ROLE middleware: role=%s, path=%s", role, c.Request.URL.Path)
 				}
 			}
 		}
-		
+
 		c.Next()
 	}
 }

--- a/pkg/api/routes.go
+++ b/pkg/api/routes.go
@@ -13,6 +13,7 @@ func SetupMiddlewares(group *gin.RouterGroup) {
 	}
 
 	group.Use(dbCheckMiddleware())
+	group.Use(roleInjectionMiddleware())  // Add role injection after db check
 }
 
 func SetupRoutes(router *gin.Engine) {

--- a/pkg/api/routes.go
+++ b/pkg/api/routes.go
@@ -13,7 +13,7 @@ func SetupMiddlewares(group *gin.RouterGroup) {
 	}
 
 	group.Use(dbCheckMiddleware())
-	group.Use(roleInjectionMiddleware())  // Add role injection after db check
+	group.Use(roleInjectionMiddleware()) // Add role injection after db check
 }
 
 func SetupRoutes(router *gin.Engine) {


### PR DESCRIPTION
- Tenant isolation with RLS allowing dynamic role management based on request headers.
- Added roleInjectionMiddleware to extract the X-Database-Role header and set the role on the database client for each request.
- Updated the Client struct to store the default role and modified query execution methods to prepend the SET ROLE command if a role is specified.
- Included validation for role names to prevent injection attacks.

Ref #15