### PR TITLE
optimize github workflow to prevent Docker build on push to main

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -5,14 +5,13 @@ on:
     branches:
       - main
     paths-ignore:
-      - '**.md'
+      - "**.md"
   pull_request:
     types:
       - opened
       - synchronize
     paths-ignore:
-      - '**.md'
-
+      - "**.md"
 
 env:
   GO_VERSION: "1.22"
@@ -28,7 +27,7 @@ jobs:
     timeout-minutes: 40
     strategy:
       matrix:
-        pg_version: ${{ github.event_name == 'pull_request' && fromJSON('[13, 15, 17]') || fromJSON('[9.6, 10, 11, 12, 13, 14, 15, 16, 17]') }}
+        pg_version: ${{ github.event_name == 'pull_request' && fromJSON('[17]') || fromJSON('[9.6, 10, 11, 12, 13, 14, 15, 16, 17]') }}
 
     services:
       postgres:
@@ -40,10 +39,10 @@ jobs:
         ports:
           - 5432:5432
         options: >-
-            --health-cmd pg_isready
-            --health-interval 10s
-            --health-timeout 5s
-            --health-retries 5
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
     steps:
       - name: Install latest Postgres client
         run: |
@@ -115,34 +114,3 @@ jobs:
           cache: true
       - run: go mod download
       - run: script/check_formatting.sh
-
-  docker-build:
-    name: docker build
-    runs-on: ubuntu-latest
-    timeout-minutes: 30
-    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
-    needs: [tests, lint, fmt]
-    env:
-      CGO_ENABLED: 0
-
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
-
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
-
-      - name: Configure docker build context
-        uses: docker/setup-buildx-action@v3
-
-      - name: Build docker images
-        uses: docker/build-push-action@v5
-        with:
-          context: .
-          push: false
-          tags: pgweb:latest
-          platforms: linux/amd64,linux/arm64,linux/arm/v7
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
-          build-args: |
-            "CGO_ENABLED=${{ env.CGO_ENABLED }}"


### PR DESCRIPTION
- Adjusted PostgreSQL version matrix for pull requests to only test version 17.
- Removed the docker-build job to save time in CI/CD process.