### PR TITLE
feat: add an option to hide active parameter overlay

### DIFF
--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -585,7 +585,14 @@ func HandleQuery(query string, c *gin.Context) {
 		query = string(rawQuery)
 	}
 
-	result, err := DB(c).Query(query)
+	// Extract URL parameters and set them on the client for substitution
+	client := DB(c)
+	urlParams := extractURLParams(c)
+	if len(urlParams) > 0 {
+		client.SetURLParams(urlParams)
+	}
+
+	result, err := client.Query(query)
 	if err != nil {
 		badRequest(c, err)
 		return

--- a/static/js/app.js
+++ b/static/js/app.js
@@ -1264,6 +1264,11 @@ function displayURLParameters() {
   var sqlParams = {};
   var hasParams = false;
 
+  // Check if parameter indicator should be hidden
+  if (urlParams.get('hideParamIndicator') === 'true') {
+    return;
+  }
+
   // Extract SQL-relevant parameters (matching backend patterns)
   var paramPatterns = [/^gsr_\w+$/, /^tenant_\w+$/, /^user_\w+$/, /^client_\w+$/, /^app_\w+$/];
   
@@ -1283,7 +1288,7 @@ function displayURLParameters() {
 
   if (hasParams) {
     // Create a small indicator showing active parameters
-    var paramDisplay = '<div id="url-params-indicator" style="position: absolute; top: 10px; right: 10px; background: rgba(0,123,255,0.1); border: 1px solid #007bff; border-radius: 4px; padding: 5px 10px; font-size: 12px; z-index: 1000;">';
+    var paramDisplay = '<div id="url-params-indicator" style="position: absolute; top: 70px; right: 10px; background: rgba(0,123,255,0.1); border: 1px solid #007bff; border-radius: 4px; padding: 5px 10px; font-size: 12px; z-index: 1000;">';
     paramDisplay += '<strong>Active Parameters:</strong><br>';
     
     for (var key in sqlParams) {


### PR DESCRIPTION
- Conditionally hide the parameter indicator based on URL parameters.
- Move active parameter overlay 70px from top to prevent conflict with navigation header
- fix parameter substitution, updated `HandleQuery` function to extract and set URL parameters for SQL query substitution.